### PR TITLE
Support for simple text blocks with no HTML and basic styling

### DIFF
--- a/Sources/BuilderIO/Components/RenderBlock.swift
+++ b/Sources/BuilderIO/Components/RenderBlock.swift
@@ -8,19 +8,6 @@ struct RenderBlock: View {
     var body: some View {
         let finalStyles = CSS.getFinalStyle(responsiveStyles: block.responsiveStyles );
         let textAlignValue = finalStyles["textAlign"]
-//        let displayValue = getStyleValue("display")
-//        let flexDirection = getStyleValue("flexDirection")
-//        let position = getStyleValue("position")
-//        let flexShrink = getStyleValue("flexShrink")
-//        let boxSizing = getStyleValue("boxSizing")
-//        let marginTop = getStyleValue("marginTop")
-//        let appearance = getStyleValue("appearance")
-//        let color = getStyleValue("color")
-//        let cursor = getStyleValue("cursor")
-//        let marginLeft = getStyleValue("marginLeft")
-//        let width = getStyleValue("width")
-//        let alignSelf = getStyleValue("alignSelf")
-//        let fontSize = getFloatValue(cssString: "fontSize") ?? 0.
         
         VStack {
             if #available(iOS 16.0, *) {
@@ -30,7 +17,6 @@ struct RenderBlock: View {
                     let name = block.component?.name
                     if name != nil {
                         let factoryValue = componentDict[name!]
-                        //                    print("componentDict[name!] = \(componentDict[name!])")
                         
                         if factoryValue != nil && block.component?.options! != nil {
                             AnyView(_fromValue: factoryValue!(block.component!.options!, finalStyles))
@@ -45,8 +31,7 @@ struct RenderBlock: View {
                 }
                 .padding(CSS.getBoxStyle(boxStyleProperty: "margin", finalStyles: finalStyles)) // margin
                 .multilineTextAlignment(textAlignValue == "center" ? .center : textAlignValue == "right" ? .trailing : .leading)
-                .font(.title)
-                .fontWeight(Font.Weight.bold)
+                
             } else {
                 // Fallback on earlier versions
             }

--- a/Sources/BuilderIO/Helpers/CSSStyleUtil.swift
+++ b/Sources/BuilderIO/Helpers/CSSStyleUtil.swift
@@ -90,10 +90,6 @@ class CSSStyleUtil {
             let directions = ["Top", "Left", "Bottom", "Right"];
             for direction in directions {
                 if finalStyles[boxStyleProperty + direction] != nil {
-                    let _ = print("BOX STYLES = ", boxStyleProperty, (EdgeInsets(top: getFloatValue(cssString: finalStyles[boxStyleProperty + "Top"]),
-                                      leading: getFloatValue(cssString: finalStyles[boxStyleProperty + "Left"]),
-                                      bottom: getFloatValue(cssString: finalStyles[boxStyleProperty + "Bottom"]),
-                                      trailing: getFloatValue(cssString: finalStyles[boxStyleProperty + "Right"]))))
                     return EdgeInsets(top: getFloatValue(cssString: finalStyles[boxStyleProperty + "Top"]),
                                       leading: getFloatValue(cssString: finalStyles[boxStyleProperty + "Left"]),
                                       bottom: getFloatValue(cssString: finalStyles[boxStyleProperty + "Bottom"]),

--- a/Sources/BuilderIO/Helpers/Content.swift
+++ b/Sources/BuilderIO/Helpers/Content.swift
@@ -13,18 +13,10 @@ public struct Content {
             }
             let decoder = JSONDecoder()
             let jsonString = String(data: data, encoding: .utf8)!
-            print("jsonString = \(jsonString)")
             do {
                 let content = try decoder.decode(BuilderContentList.self, from: Data(jsonString.utf8))
                 if content.results.count>0 {
                     callback(content.results[0])
-                    
-                    print("file = \(#file) \(#function) \(#line)")
-                    print("content.results[0].data.blocks[0] = \(String(describing: content.results[0].data.blocks[0]))")
-                    
-                    
-                    
-                    print("responsiveStyles = \(String(describing: content.results[0].data.blocks[0].responsiveStyles))")
                 }
             } catch {
                 print(error)

--- a/Sources/BuilderIO/Helpers/RenderContent.swift
+++ b/Sources/BuilderIO/Helpers/RenderContent.swift
@@ -9,14 +9,12 @@ public struct RenderContent: View {
         if (!RenderContent.registered) {
             // TODO: move these out of here?
             registerComponent(name: "Text", factory: { (options, styles) in
-                print("Text \n titleString = "+options["text"].stringValue+" \n options = \(options)")
                 return BuilderText(text: options["text"].stringValue, responsiveStyles: styles)
             })
             registerComponent(name: "Image", factory: { (options, styles) in
                 return BuilderImage(image: options["image"].stringValue, backgroundSize: options["backgroundSize: <#T##String#>"].stringValue)
             })
             registerComponent(name: "Core:Button", factory: { (options, styles) in
-                // print("Core:Button \n titleString = "+options["text"].stringValue+" \n options = \(options)")
                 return BuilderButton(text: options["text"].stringValue, urlStr: options["link"].stringValue, openInNewTab: options["openLinkInNewTab"].boolValue, responsiveStyles: styles)
             })
             registerComponent(name: "Columns", factory: { (options, styles) in


### PR DESCRIPTION
Support for text blocks
- Font size and weight
- Background and text color
- Padding / margins

Input:
<img width="381" alt="image" src="https://user-images.githubusercontent.com/97863898/205332094-81405502-46fd-42db-a931-a7863ec585b0.png">


Rendered:
<img width="389" alt="image" src="https://user-images.githubusercontent.com/97863898/205332221-fa61476c-0352-41af-85d5-a1caa2abe562.png">

