### PR TITLE
Fix horizontal alignment, full width for text and buttons

### DIFF
--- a/Sources/BuilderIO/Blocks/BuilderButton.swift
+++ b/Sources/BuilderIO/Blocks/BuilderButton.swift
@@ -18,6 +18,7 @@ struct BuilderButton: View {
         let cornerRadius = CSS.getFloatValue(cssString:responsiveStyles?["borderRadius"] ?? "0px")
         let fontSize = CSS.getFloatValue(cssString: responsiveStyles?["fontSize"] ?? "16px")
         let fontWeight = CSS.getFontWeightFromNumber(value: CSS.getFloatValue(cssString: responsiveStyles?["fontWeight"] ?? "400"))
+        let horizontalAlignmentFrame = CSS.getFrameFromHorizontalAlignment(styles: responsiveStyles ?? [:]);
         Button(action: {
             print(CSS.getTextWithoutHtml(text))
             // print("responsiveStyles = \(String(describing: responsiveStyles))")
@@ -31,8 +32,10 @@ struct BuilderButton: View {
             Text(CSS.getTextWithoutHtml(text))
                 .padding(CSS.getBoxStyle(boxStyleProperty: "padding", finalStyles: responsiveStyles ?? [:])) // padding for the button
                 .font(.system(size: fontSize).weight(fontWeight))
+                .frame(alignment: horizontalAlignmentFrame.alignment)
                 
         }
+        .frame(idealWidth: horizontalAlignmentFrame.idealWidth, maxWidth: horizontalAlignmentFrame.maxWidth, alignment: horizontalAlignmentFrame.alignment)
         .foregroundColor(foregroundColor)
         .background(RoundedRectangle(cornerRadius: cornerRadius).fill(bgColor))
             

--- a/Sources/BuilderIO/Blocks/BuilderText.swift
+++ b/Sources/BuilderIO/Blocks/BuilderText.swift
@@ -15,13 +15,15 @@ struct BuilderText: View {
         let cornerRadius = CSS.getFloatValue(cssString:responsiveStyles?["borderRadius"] ?? "0px")
         let fontSize = CSS.getFloatValue(cssString: responsiveStyles?["fontSize"] ?? "16px")
         let fontWeight = CSS.getFontWeightFromNumber(value: CSS.getFloatValue(cssString: responsiveStyles?["fontWeight"] ?? "400"))
-        let _ = print("Setting", fontSize, fontWeight, "for text", CSS.getTextWithoutHtml(text))
+        let _ = print("Text", CSS.getTextWithoutHtml(text))
+        let horizontalAlignmentFrame = CSS.getFrameFromHorizontalAlignment(styles: responsiveStyles ?? [:]);
         Text(CSS.getTextWithoutHtml(text))
-            .frame(minWidth: 0, maxWidth: .infinity, minHeight: 0, maxHeight: .infinity, alignment: .center)
             .padding(CSS.getBoxStyle(boxStyleProperty: "padding", finalStyles: responsiveStyles ?? [:])) // padding for the button
+            .frame(idealWidth: horizontalAlignmentFrame.idealWidth, maxWidth: horizontalAlignmentFrame.maxWidth, alignment: horizontalAlignmentFrame.alignment)
             .font(.system(size: fontSize).weight(fontWeight))
             .foregroundColor(foregroundColor)
             .background(RoundedRectangle(cornerRadius: cornerRadius).fill(bgColor))
+            
     }
 }
 

--- a/Sources/BuilderIO/Components/RenderBlock.swift
+++ b/Sources/BuilderIO/Components/RenderBlock.swift
@@ -8,11 +8,11 @@ struct RenderBlock: View {
     var body: some View {
         let finalStyles = CSS.getFinalStyle(responsiveStyles: block.responsiveStyles );
         let textAlignValue = finalStyles["textAlign"]
+        let horizontalAlignment = CSS.getHorizontalAlignmentFromMargin(styles: finalStyles)
+        let alignment = horizontalAlignment == HorizontalAlignment.LeftAlign ? Alignment.leading : (horizontalAlignment == HorizontalAlignment.Center ? Alignment.center : Alignment.trailing)
         
         VStack {
             if #available(iOS 16.0, *) {
-                
-                
                 VStack(alignment: .center) {
                     let name = block.component?.name
                     if name != nil {
@@ -31,6 +31,7 @@ struct RenderBlock: View {
                 }
                 .padding(CSS.getBoxStyle(boxStyleProperty: "margin", finalStyles: finalStyles)) // margin
                 .multilineTextAlignment(textAlignValue == "center" ? .center : textAlignValue == "right" ? .trailing : .leading)
+                .frame(minWidth: 0, idealWidth: .infinity, maxWidth: .infinity, alignment: alignment)
                 
             } else {
                 // Fallback on earlier versions

--- a/Sources/BuilderIO/Helpers/CSSStyleUtil.swift
+++ b/Sources/BuilderIO/Helpers/CSSStyleUtil.swift
@@ -2,6 +2,21 @@
 import Foundation
 import SwiftUI
 
+enum HorizontalAlignment {
+    case FullWidth
+    case Center
+    case LeftAlign
+    case RightAlign
+}
+
+@available(iOS 13.0, *)
+struct FrameDimensions {
+    var minWidth: CGFloat? = nil;
+    var idealWidth: CGFloat? = nil;
+    var maxWidth: CGFloat? = nil;
+    var alignment: Alignment;
+}
+
 class CSSStyleUtil {
     /*
      Takes the responsive styles from Builder blocks response, and
@@ -109,6 +124,45 @@ class CSSStyleUtil {
         }
         
         return ""
+    }
+    
+    static func getHorizontalAlignmentFromMargin(styles: [String: String]) -> HorizontalAlignment {
+        let marginLeft = styles["marginLeft"]
+        let marginRight = styles["marginRight"]
+        
+        let isMarginLeftAbsentOrZero = marginLeft == nil || getFloatValue(cssString: marginLeft) == CGFloat(0);
+        let isMarginRightAbsentOrZero = marginRight == nil || getFloatValue(cssString: marginRight) == CGFloat(0);
+        let isMarginLeftAuto = marginLeft?.lowercased() == "auto";
+        let isMarginRightAuto = marginRight?.lowercased() == "auto";
+        
+        if (isMarginLeftAuto && isMarginRightAuto) {
+            return HorizontalAlignment.Center;
+        } else if (isMarginLeftAuto) {
+            return HorizontalAlignment.RightAlign;
+        } else if (isMarginRightAuto) {
+            return HorizontalAlignment.LeftAlign;
+        } else if (isMarginLeftAbsentOrZero && isMarginRightAbsentOrZero) {
+            return HorizontalAlignment.FullWidth;
+        } 
+        // Default full width?
+        return HorizontalAlignment.FullWidth;
+    }
+    
+    @available(iOS 13.0, *)
+    static func getFrameFromHorizontalAlignment(styles: [String: String]) -> FrameDimensions {
+        let horizontalAlignment = getHorizontalAlignmentFromMargin(styles: styles)
+        
+        if (horizontalAlignment == HorizontalAlignment.FullWidth) {
+            return FrameDimensions(minWidth: 0, idealWidth: .infinity, maxWidth: .infinity, alignment: .center)
+            
+        } else if (horizontalAlignment == HorizontalAlignment.Center) {
+            return FrameDimensions(alignment: .center)
+        } else if (horizontalAlignment == HorizontalAlignment.LeftAlign) {
+            return FrameDimensions(alignment: .leading)
+        } else {
+            // Right align
+            return FrameDimensions(alignment: .trailing)
+        }
     }
     
     @available(iOS 13.0, *)


### PR DESCRIPTION
Add support for Horizontal alignment for buttons and text, specifically:

* Full Width
* Center
* Left Align
* Right Align

**Screenshots** 

_**Builder**_

Buttons:
<img width="364" alt="image" src="https://user-images.githubusercontent.com/97863898/205905436-01ee756a-2851-48f5-a455-947ea9a729bb.png">

Text: 
<img width="349" alt="image" src="https://user-images.githubusercontent.com/97863898/205905526-bb81ea48-8fb4-45c0-98b3-591560a2fcea.png">


_**iOS**_

Buttons: 
![image](https://user-images.githubusercontent.com/97863898/205905295-0fa4f71d-54e5-4cba-8d1f-279e291f45d5.png)

Text: 
![image](https://user-images.githubusercontent.com/97863898/205905323-d05d00f6-74c7-43e8-85a3-90619d284ee7.png)
