### PR TITLE
Added localization support

### DIFF
--- a/Sources/BuilderIO/BuilderIOManager.swift
+++ b/Sources/BuilderIO/BuilderIOManager.swift
@@ -50,9 +50,11 @@ public final class BuilderIOManager {
     return customNavigationScheme
   }
 
-  public func fetchBuilderContent(model: String = "page", url: String? = nil) async -> Result<
-    BuilderContent, Error
-  > {
+  public func fetchBuilderContent(model: String = "page", url: String? = nil, locale: String) async
+    -> Result<
+      BuilderContent, Error
+    >
+  {
     do {
       let resolvedUrl = url ?? ""
 
@@ -60,7 +62,7 @@ public final class BuilderIOManager {
         model: model,
         apiKey: apiKey,
         url: resolvedUrl,
-        locale: nil,  //Always send to nil so as to get all options to allow for local changes without requiring an API call
+        locale: locale,
         preview: ""
       ) {
         return .success(content)

--- a/Sources/BuilderIO/BuilderIOManager.swift
+++ b/Sources/BuilderIO/BuilderIOManager.swift
@@ -15,24 +15,26 @@ public final class BuilderIOManager {
 
   private let apiKey: String
   public let customNavigationScheme: String
+  public let locale: String?
 
   private static var registered = false
 
-  public static func configure(apiKey: String, customNavigationScheme: String = "builderio") {
+  public static func configure(apiKey: String, customNavigationScheme: String = "builderio", locale: String = "Default") {
     guard _shared == nil else {
       print(
         "Warning: BuilderIOManager has already been configured. Ignoring subsequent configuration.")
       return
     }
     Font.registerFonts()
-    _shared = BuilderIOManager(apiKey: apiKey, customNavigationScheme: customNavigationScheme)
+    _shared = BuilderIOManager(apiKey: apiKey, customNavigationScheme: customNavigationScheme, locale: locale)
   }
 
   // MARK: - Private Initialization
 
-  private init(apiKey: String, customNavigationScheme: String) {
+  private init(apiKey: String, customNavigationScheme: String, locale: String) {
     self.apiKey = apiKey
     self.customNavigationScheme = customNavigationScheme
+    self.locale = locale
 
     if !Self.registered {
       BuilderComponentRegistry.shared.initialize()
@@ -60,7 +62,7 @@ public final class BuilderIOManager {
         model: model,
         apiKey: apiKey,
         url: resolvedUrl,
-        locale: "",
+        locale: locale,
         preview: ""
       ) {
         return .success(content)

--- a/Sources/BuilderIO/BuilderIOManager.swift
+++ b/Sources/BuilderIO/BuilderIOManager.swift
@@ -15,26 +15,24 @@ public final class BuilderIOManager {
 
   private let apiKey: String
   public let customNavigationScheme: String
-  public let locale: String?
 
   private static var registered = false
 
-  public static func configure(apiKey: String, customNavigationScheme: String = "builderio", locale: String = "Default") {
+  public static func configure(apiKey: String, customNavigationScheme: String = "builderio") {
     guard _shared == nil else {
       print(
         "Warning: BuilderIOManager has already been configured. Ignoring subsequent configuration.")
       return
     }
     Font.registerFonts()
-    _shared = BuilderIOManager(apiKey: apiKey, customNavigationScheme: customNavigationScheme, locale: locale)
+    _shared = BuilderIOManager(apiKey: apiKey, customNavigationScheme: customNavigationScheme)
   }
 
   // MARK: - Private Initialization
 
-  private init(apiKey: String, customNavigationScheme: String, locale: String) {
+  private init(apiKey: String, customNavigationScheme: String) {
     self.apiKey = apiKey
     self.customNavigationScheme = customNavigationScheme
-    self.locale = locale
 
     if !Self.registered {
       BuilderComponentRegistry.shared.initialize()
@@ -62,7 +60,7 @@ public final class BuilderIOManager {
         model: model,
         apiKey: apiKey,
         url: resolvedUrl,
-        locale: locale,
+        locale: nil,  //Always send to nil so as to get all options to allow for local changes without requiring an API call
         preview: ""
       ) {
         return .success(content)

--- a/Sources/BuilderIO/BuilderIOManager.swift
+++ b/Sources/BuilderIO/BuilderIOManager.swift
@@ -51,9 +51,7 @@ public final class BuilderIOManager {
   }
 
   public func fetchBuilderContent(model: String = "page", url: String? = nil, locale: String) async
-    -> Result<
-      BuilderContent, Error
-    >
+    -> Result<BuilderContent, Error>
   {
     do {
       let resolvedUrl = url ?? ""

--- a/Sources/BuilderIO/BuilderIOManager.swift
+++ b/Sources/BuilderIO/BuilderIOManager.swift
@@ -15,29 +15,24 @@ public final class BuilderIOManager {
 
   private let apiKey: String
   public let customNavigationScheme: String
-  public let locale: String?
 
   private static var registered = false
 
-  public static func configure(
-    apiKey: String, customNavigationScheme: String = "builderio", locale: String? = nil
-  ) {
+  public static func configure(apiKey: String, customNavigationScheme: String = "builderio") {
     guard _shared == nil else {
       print(
         "Warning: BuilderIOManager has already been configured. Ignoring subsequent configuration.")
       return
     }
     Font.registerFonts()
-    _shared = BuilderIOManager(
-      apiKey: apiKey, customNavigationScheme: customNavigationScheme, locale: locale)
+    _shared = BuilderIOManager(apiKey: apiKey, customNavigationScheme: customNavigationScheme)
   }
 
   // MARK: - Private Initialization
 
-  private init(apiKey: String, customNavigationScheme: String, locale: String?) {
+  private init(apiKey: String, customNavigationScheme: String) {
     self.apiKey = apiKey
     self.customNavigationScheme = customNavigationScheme
-    self.locale = locale
 
     if !Self.registered {
       BuilderComponentRegistry.shared.initialize()
@@ -65,7 +60,7 @@ public final class BuilderIOManager {
         model: model,
         apiKey: apiKey,
         url: resolvedUrl,
-        locale: locale ?? "",
+        locale: "",
         preview: ""
       ) {
         return .success(content)

--- a/Sources/BuilderIO/BuilderIOManager.swift
+++ b/Sources/BuilderIO/BuilderIOManager.swift
@@ -15,24 +15,29 @@ public final class BuilderIOManager {
 
   private let apiKey: String
   public let customNavigationScheme: String
+  public let locale: String?
 
   private static var registered = false
 
-  public static func configure(apiKey: String, customNavigationScheme: String = "builderio") {
+  public static func configure(
+    apiKey: String, customNavigationScheme: String = "builderio", locale: String? = nil
+  ) {
     guard _shared == nil else {
       print(
         "Warning: BuilderIOManager has already been configured. Ignoring subsequent configuration.")
       return
     }
     Font.registerFonts()
-    _shared = BuilderIOManager(apiKey: apiKey, customNavigationScheme: customNavigationScheme)
+    _shared = BuilderIOManager(
+      apiKey: apiKey, customNavigationScheme: customNavigationScheme, locale: locale)
   }
 
   // MARK: - Private Initialization
 
-  private init(apiKey: String, customNavigationScheme: String) {
+  private init(apiKey: String, customNavigationScheme: String, locale: String?) {
     self.apiKey = apiKey
     self.customNavigationScheme = customNavigationScheme
+    self.locale = locale
 
     if !Self.registered {
       BuilderComponentRegistry.shared.initialize()
@@ -60,7 +65,7 @@ public final class BuilderIOManager {
         model: model,
         apiKey: apiKey,
         url: resolvedUrl,
-        locale: "",
+        locale: locale ?? "",
         preview: ""
       ) {
         return .success(content)

--- a/Sources/BuilderIO/ComponentRegistry/BuilderComponentProtocol.swift
+++ b/Sources/BuilderIO/ComponentRegistry/BuilderComponentProtocol.swift
@@ -22,7 +22,7 @@ extension BuilderViewProtocol {
   func localize(localizedValue: AnyCodable) -> String? {
 
     if let localeDictionary = localizedValue.dictionaryValue {
-      if let currentLocale = BuilderIOManager.shared.locale {
+      if let currentLocale = block.locale {
         if let localizedString = localeDictionary[currentLocale]?.stringValue {
           return localizedString
         }

--- a/Sources/BuilderIO/ComponentRegistry/BuilderComponentProtocol.swift
+++ b/Sources/BuilderIO/ComponentRegistry/BuilderComponentProtocol.swift
@@ -18,6 +18,22 @@ extension BuilderViewProtocol {
   func codeBindings() -> [String: String]? {
     return nil
   }
+
+  func localize(localizedValue: AnyCodable) -> String? {
+
+    if let localeDictionary = localizedValue.dictionaryValue {
+      if let currentLocale = BuilderIOManager.shared.locale {
+        if let localizedString = localeDictionary[currentLocale]?.stringValue {
+          return localizedString
+        }
+      }
+
+      return localeDictionary["Default"]?.stringValue
+
+    } else {
+      return localizedValue.stringValue
+    }
+  }
 }
 
 struct BuilderEmptyView: BuilderViewProtocol {

--- a/Sources/BuilderIO/ComponentRegistry/BuilderComponentProtocol.swift
+++ b/Sources/BuilderIO/ComponentRegistry/BuilderComponentProtocol.swift
@@ -18,22 +18,6 @@ extension BuilderViewProtocol {
   func codeBindings() -> [String: String]? {
     return nil
   }
-
-  func localize(localizedValue: AnyCodable) -> String? {
-
-    if let localeDictionary = localizedValue.dictionaryValue {
-      if let currentLocale = BuilderIOManager.shared.locale {
-        if let localizedString = localeDictionary[currentLocale]?.stringValue {
-          return localizedString
-        }
-      }
-
-      return localeDictionary["Default"]?.stringValue
-
-    } else {
-      return localizedValue.stringValue
-    }
-  }
 }
 
 struct BuilderEmptyView: BuilderViewProtocol {

--- a/Sources/BuilderIO/Components/BuilderColumns.swift
+++ b/Sources/BuilderIO/Components/BuilderColumns.swift
@@ -51,9 +51,9 @@ struct BuilderColumns: BuilderViewProtocol {
           }
         }
       }
-      
+
       if let locale = block.locale {
-        
+
         for columnIndex in decodedColumns.indices {
           for blockIndex in decodedColumns[columnIndex].blocks.indices {
             decodedColumns[columnIndex].blocks[blockIndex]

--- a/Sources/BuilderIO/Components/BuilderColumns.swift
+++ b/Sources/BuilderIO/Components/BuilderColumns.swift
@@ -51,6 +51,16 @@ struct BuilderColumns: BuilderViewProtocol {
           }
         }
       }
+      
+      if let locale = block.locale {
+        
+        for columnIndex in decodedColumns.indices {
+          for blockIndex in decodedColumns[columnIndex].blocks.indices {
+            decodedColumns[columnIndex].blocks[blockIndex]
+              .setLocaleRecursively(locale)
+          }
+        }
+      }
 
       self.columns = decodedColumns
 

--- a/Sources/BuilderIO/Components/BuilderImage.swift
+++ b/Sources/BuilderIO/Components/BuilderImage.swift
@@ -6,7 +6,7 @@ struct BuilderImage: BuilderViewProtocol {
   var block: BuilderBlockModel
   var children: [BuilderBlockModel]?
 
-  var imageURL: URL? = nil
+  var imageURL: URL?
   var aspectRatio: CGFloat? = nil
   var lockAspectRatio: Bool = false
   var contentMode: ContentMode = .fit
@@ -16,12 +16,8 @@ struct BuilderImage: BuilderViewProtocol {
 
   init(block: BuilderBlockModel) {
     self.block = block
-
-    if let imageLink = block.component?.options?.dictionaryValue?["image"] {
-      self.imageURL = URL(
-        string: localize(localizedValue: imageLink) ?? "")
-    }
-
+    self.imageURL = URL(
+      string: block.component?.options?.dictionaryValue?["image"]?.stringValue ?? "")
     if let ratio = block.component?.options?.dictionaryValue?["aspectRatio"]?.doubleValue {
       self.aspectRatio = CGFloat(1 / ratio)
     }

--- a/Sources/BuilderIO/Components/BuilderImage.swift
+++ b/Sources/BuilderIO/Components/BuilderImage.swift
@@ -6,7 +6,7 @@ struct BuilderImage: BuilderViewProtocol {
   var block: BuilderBlockModel
   var children: [BuilderBlockModel]?
 
-  var imageURL: URL?
+  var imageURL: URL? = nil
   var aspectRatio: CGFloat? = nil
   var lockAspectRatio: Bool = false
   var contentMode: ContentMode = .fit
@@ -16,8 +16,12 @@ struct BuilderImage: BuilderViewProtocol {
 
   init(block: BuilderBlockModel) {
     self.block = block
-    self.imageURL = URL(
-      string: block.component?.options?.dictionaryValue?["image"]?.stringValue ?? "")
+
+    if let imageLink = block.component?.options?.dictionaryValue?["image"] {
+      self.imageURL = URL(
+        string: localize(localizedValue: imageLink) ?? "")
+    }
+
     if let ratio = block.component?.options?.dictionaryValue?["aspectRatio"]?.doubleValue {
       self.aspectRatio = CGFloat(1 / ratio)
     }

--- a/Sources/BuilderIO/Components/BuilderText.swift
+++ b/Sources/BuilderIO/Components/BuilderText.swift
@@ -11,11 +11,7 @@ struct BuilderText: BuilderViewProtocol {
 
   init(block: BuilderBlockModel) {
     self.block = block
-
-    if let textValue = block.component?.options?.dictionaryValue?["text"] {
-      self.text = localize(localizedValue: textValue) ?? ""
-    }
-
+    self.text = block.component?.options?.dictionaryValue?["text"]?.stringValue ?? ""
     self.responsiveStyles = getFinalStyle(responsiveStyles: block.responsiveStyles)
 
     if let textBinding = block.codeBindings(for: "text") {

--- a/Sources/BuilderIO/Components/BuilderText.swift
+++ b/Sources/BuilderIO/Components/BuilderText.swift
@@ -11,7 +11,11 @@ struct BuilderText: BuilderViewProtocol {
 
   init(block: BuilderBlockModel) {
     self.block = block
-    self.text = block.component?.options?.dictionaryValue?["text"]?.stringValue ?? ""
+
+    if let textValue = block.component?.options?.dictionaryValue?["text"] {
+      self.text = localize(localizedValue: textValue) ?? ""
+    }
+
     self.responsiveStyles = getFinalStyle(responsiveStyles: block.responsiveStyles)
 
     if let textBinding = block.codeBindings(for: "text") {

--- a/Sources/BuilderIO/Components/BuilderText.swift
+++ b/Sources/BuilderIO/Components/BuilderText.swift
@@ -11,7 +11,7 @@ struct BuilderText: BuilderViewProtocol {
 
   init(block: BuilderBlockModel) {
     self.block = block
-
+    var processedText: String = ""
     if let textValue = block.component?.options?.dictionaryValue?["text"] {
       self.text = localize(localizedValue: textValue) ?? ""
     }
@@ -110,12 +110,25 @@ struct HTMLTextView: View {
       // Perform the NSAttributedString conversion on the MainActor
       await MainActor.run {
         do {
-          let nsAttributedString = try NSAttributedString(
-            data: data,
-            options: [
+
+          var attributedOptions: [NSAttributedString.DocumentReadingOptionKey: Any] = [:]
+
+          if #available(iOS 18.0, *) {
+            attributedOptions = [
               .documentType: NSAttributedString.DocumentType.html,
               .characterEncoding: String.Encoding.utf8.rawValue,
-            ],
+              .textKit1ListMarkerFormatDocumentOption: true,
+            ]
+          } else {
+            attributedOptions = [
+              .documentType: NSAttributedString.DocumentType.html,
+              .characterEncoding: String.Encoding.utf8.rawValue,
+            ]
+          }
+
+          let nsAttributedString = try NSAttributedString(
+            data: data,
+            options: attributedOptions,
             documentAttributes: nil
           )
 
@@ -125,6 +138,7 @@ struct HTMLTextView: View {
           else {
             throw HTMLProcessingError.attributedStringConversionFailed
           }
+
           self.attributedString = swiftUIAttributedString
           self.errorInProcessing = nil  // Clear error if successful
         } catch {
@@ -230,74 +244,4 @@ struct HTMLTextView: View {
     }
   }
 
-}
-
-struct BuilderText_Previews: PreviewProvider {
-  static let builderJSONString = """
-    {
-             "@type": "@builder.io/sdk:Element",
-             "@version": 2,
-             "id": "builder-54d67576377d4a9293c6f8d2efcda0ef",
-             "meta": {
-               "previousId": "builder-ad756879bc6c4ee3ac7977d5af0b6811"
-             },
-             "component": {
-               "name": "Text",
-              "options": {
-                "text": "<h1><strong>Right<em> </em></strong><em>Align</em><strong><em> </em></strong><strong style=\\\"color: rgb(144, 19, 254);\\\"><em><u>Text</u></em></strong></h1><p> This is a paragraph with some content that will determine the height dynamically. This text should wrap to multiple lines if the width is constrained.</p>"
-              },
-               "isRSC": null
-             },
-             "responsiveStyles": {
-               "large": {
-                 "display": "flex",
-                 "flexDirection": "column",
-                 "position": "relative",
-                 "flexShrink": "0",
-                 "boxSizing": "border-box",
-                 "marginTop": "20px",
-                 "lineHeight": "normal",
-                 "height": "auto",
-                 "marginLeft": "auto",
-                 "paddingLeft": "20px",
-                 "marginRight": "20px"
-               },
-               "medium": {
-                 "display": "none"
-               },
-               "small": {
-                 "borderWidth": "2px",
-                 "borderStyle": "solid",
-                 "borderColor": "rgba(219, 20, 20, 1)",
-                 "backgroundColor": "rgba(80, 227, 194, 1)",
-                 "backgroundRepeat": "no-repeat",
-                 "backgroundPosition": "center",
-                 "backgroundSize": "cover",
-                 "display": "flex",
-                 "fontSize": "12px",
-                 "fontWeight": "600",
-                 "fontFamily": "Aldrich, sans-serif"
-               }
-             }
-           }
-    """
-
-  static func decodeBuilderBlockModel(from jsonString: String) -> BuilderBlockModel? {
-    let data = Data(jsonString.utf8)
-    do {
-      let decoder = JSONDecoder()
-      return try decoder.decode(BuilderBlockModel.self, from: data)
-    } catch {
-      print("Decoding failed:", error)
-      return nil
-    }
-  }
-
-  static var previews: some View {
-    if let block = decodeBuilderBlockModel(from: builderJSONString) {
-      BuilderText(block: block)
-    } else {
-      Text("Failed to decode block")
-    }
-  }
 }

--- a/Sources/BuilderIO/ExportedView/BuilderIOContentView.swift
+++ b/Sources/BuilderIO/ExportedView/BuilderIOContentView.swift
@@ -9,18 +9,18 @@ public struct BuilderIOContentView: View {
   @State private var viewModel: BuilderIOViewModel
   @Binding var locale: String
 
-  public init(model: String, locale: String) {
+  public init(model: String, locale: String = "Default") {
     self.init(model: model, locale: .constant(locale))
   }
 
   public init(model: String, locale: Binding<String>) {
     self.model = model
     self.url = nil
-    self._locale = locale  // Initialize the binding
-    _viewModel = State(wrappedValue: BuilderIOViewModel(locale: locale.wrappedValue))
+    self._locale = locale
+    _viewModel = State(wrappedValue: BuilderIOViewModel())
   }
 
-  public init(url: String, model: String = "page", locale: String) {
+  public init(url: String, model: String = "page", locale: String = "Default") {
     self.init(url: url, model: model, locale: .constant(locale))
   }
 
@@ -28,7 +28,7 @@ public struct BuilderIOContentView: View {
     self.url = url
     self.model = model
     self._locale = locale
-    _viewModel = State(wrappedValue: BuilderIOViewModel(locale: locale.wrappedValue))
+    _viewModel = State(wrappedValue: BuilderIOViewModel())
   }
 
   public var body: some View {
@@ -78,14 +78,17 @@ public struct BuilderIOContentView: View {
         await loadContent()
       }
     }.onChange(of: locale) {
-      viewModel.updateLocale(locale: locale)
+      Task {
+        await loadContent()
+      }
     }
   }
 
   func loadContent() async {
     if !viewModel.isLoading {
       print("Calling fetchBuilderPageContent from .task for section model : \(model)")
-      await viewModel.fetchBuilderContent(model: model, url: url ?? "")
+      await viewModel.fetchBuilderContent(
+        model: model, url: url ?? "", locale: _locale.wrappedValue)
     } else if viewModel.isLoading {
       print("Already loading content for section model: \(model). Not re-fetching.")
     }

--- a/Sources/BuilderIO/ExportedView/BuilderIOContentView.swift
+++ b/Sources/BuilderIO/ExportedView/BuilderIOContentView.swift
@@ -7,17 +7,21 @@ public struct BuilderIOContentView: View {
   let url: String?
 
   @State private var viewModel: BuilderIOViewModel
+  @Binding var locale: String
 
-  public init(model: String) {
+  public init(model: String, locale: Binding<String>) {
     self.model = model
     self.url = nil
-    _viewModel = State(wrappedValue: BuilderIOViewModel())
+    self._locale = locale  // Initialize the binding
+    _viewModel = State(wrappedValue: BuilderIOViewModel(locale: locale.wrappedValue))
+
   }
 
-  init(url: String, model: String = "page") {
+  init(url: String, model: String = "page", locale: Binding<String>) {
     self.url = url
     self.model = model
-    _viewModel = State(wrappedValue: BuilderIOViewModel())
+    self._locale = locale
+    _viewModel = State(wrappedValue: BuilderIOViewModel(locale: locale.wrappedValue))
   }
 
   public var body: some View {
@@ -66,6 +70,8 @@ public struct BuilderIOContentView: View {
       if viewModel.builderContent == nil && !viewModel.isLoading {
         await loadContent()
       }
+    }.onChange(of: locale) {
+      viewModel.updateLocale(locale: locale)
     }
   }
 

--- a/Sources/BuilderIO/ExportedView/BuilderIOContentView.swift
+++ b/Sources/BuilderIO/ExportedView/BuilderIOContentView.swift
@@ -9,12 +9,20 @@ public struct BuilderIOContentView: View {
   @State private var viewModel: BuilderIOViewModel
   @Binding var locale: String
 
+  public init(model: String, locale: String) {
+    self.init(model: model, locale: .constant(locale))
+  }
+
   public init(model: String, locale: Binding<String>) {
     self.model = model
     self.url = nil
     self._locale = locale  // Initialize the binding
     _viewModel = State(wrappedValue: BuilderIOViewModel(locale: locale.wrappedValue))
 
+  }
+
+  public init(url: String, model: String = "page", locale: String) {
+    self.init(url: url, model: model, locale: .constant(locale))
   }
 
   init(url: String, model: String = "page", locale: Binding<String>) {

--- a/Sources/BuilderIO/ExportedView/BuilderIOContentView.swift
+++ b/Sources/BuilderIO/ExportedView/BuilderIOContentView.swift
@@ -18,7 +18,6 @@ public struct BuilderIOContentView: View {
     self.url = nil
     self._locale = locale  // Initialize the binding
     _viewModel = State(wrappedValue: BuilderIOViewModel(locale: locale.wrappedValue))
-
   }
 
   public init(url: String, model: String = "page", locale: String) {

--- a/Sources/BuilderIO/ExportedView/BuilderIOPage.swift
+++ b/Sources/BuilderIO/ExportedView/BuilderIOPage.swift
@@ -5,6 +5,7 @@ public struct BuilderIOPage: View {
 
   let url: String
   let model: String
+  @State private var locale: String
 
   @StateObject private var buttonActionManager = BuilderActionManager()
   var onClickEventHandler: ((BuilderAction) -> Void)? = nil
@@ -12,18 +13,24 @@ public struct BuilderIOPage: View {
   @State private var activeNavigationTarget: NavigationTarget? = nil
 
   public init(
-    url: String, model: String = "page", onClickEventHandler: ((BuilderAction) -> Void)? = nil
+    url: String, model: String = "page", locale: String = "Default",
+    onClickEventHandler: ((BuilderAction) -> Void)? = nil
   ) {
     self.url = url
     self.model = model
     self.onClickEventHandler = onClickEventHandler
+    self._locale = State(initialValue: locale)
+  }
+
+  public func updateLocale(locale: String) {
+
   }
 
   public var body: some View {
     NavigationStack(path: $buttonActionManager.path) {
-      BuilderIOContentView(url: url, model: model)
+      BuilderIOContentView(url: url, model: model, locale: $locale)
         .navigationDestination(for: NavigationTarget.self) { target in
-          BuilderIOContentView(url: target.url, model: target.model)
+          BuilderIOContentView(url: target.url, model: target.model, locale: $locale)
         }
     }.environmentObject(buttonActionManager).onAppear {
       if let onClickEventHandler = onClickEventHandler {

--- a/Sources/BuilderIO/ExportedView/BuilderIOPage.swift
+++ b/Sources/BuilderIO/ExportedView/BuilderIOPage.swift
@@ -5,7 +5,7 @@ public struct BuilderIOPage: View {
 
   let url: String
   let model: String
-  @State private var locale: String
+  @Binding var locale: String
 
   @StateObject private var buttonActionManager = BuilderActionManager()
   var onClickEventHandler: ((BuilderAction) -> Void)? = nil
@@ -16,14 +16,18 @@ public struct BuilderIOPage: View {
     url: String, model: String = "page", locale: String = "Default",
     onClickEventHandler: ((BuilderAction) -> Void)? = nil
   ) {
+    self.init(
+      url: url, model: model, locale: .constant(locale), onClickEventHandler: onClickEventHandler)
+  }
+
+  public init(
+    url: String, model: String = "page", locale: Binding<String>,
+    onClickEventHandler: ((BuilderAction) -> Void)? = nil
+  ) {
     self.url = url
     self.model = model
     self.onClickEventHandler = onClickEventHandler
-    self._locale = State(initialValue: locale)
-  }
-
-  public func updateLocale(locale: String) {
-
+    self._locale = locale
   }
 
   public var body: some View {

--- a/Sources/BuilderIO/ExportedView/BuilderIOViewModel.swift
+++ b/Sources/BuilderIO/ExportedView/BuilderIOViewModel.swift
@@ -12,24 +12,14 @@ public final class BuilderIOViewModel {
   public var isLoading: Bool = false
   public var errorMessage: String?
   public var stateModel: StateModel = StateModel()
-  public var locale: String = "Default"
 
   public var isNetworkAvailable: Bool = false
   private let networkMonitor = NWPathMonitor()
   private let networkQueue = DispatchQueue(label: "NetworkMonitorQueue")
 
   /// Initializes the BuilderIOViewModel.
-  public init(locale: String) {
-    self.locale = locale
+  public init() {
     startNetworkMonitoring()
-  }
-
-  public func updateLocale(locale: String) {
-    self.locale = locale
-    for i in 0..<(self.builderContent?.data.blocks.count ?? 0) {
-      self.builderContent?.data.blocks[i].setLocaleRecursively(locale)
-    }
-
   }
 
   private func startNetworkMonitoring() {
@@ -54,7 +44,7 @@ public final class BuilderIOViewModel {
 
   /// Fetches the Builder.io page content for a given URL.
   /// Manages loading, content, and error states.
-  public func fetchBuilderContent(model: String = "page", url: String = "") async {
+  public func fetchBuilderContent(model: String = "page", url: String = "", locale: String) async {
     // Set loading state immediately
     isLoading = true
     errorMessage = nil  // Clear any previous error
@@ -68,12 +58,13 @@ public final class BuilderIOViewModel {
 
     do {
       // Await the content fetching
-      let result = await BuilderIOManager.shared.fetchBuilderContent(model: model, url: url)
+      let result = await BuilderIOManager.shared.fetchBuilderContent(
+        model: model, url: url, locale: locale)
       switch result {
       case .success(let fetchedContent):
-        if fetchedContent.data.httpRequests != nil {
+        if let httpRequests = fetchedContent.data.httpRequests {
           self.stateModel.apiResponses = try await fetchParallelAPIData(
-            urls: fetchedContent.data.httpRequests!)
+            urls: httpRequests, locale: locale)
         }
 
         if self.stateModel.apiResponses.isEmpty {
@@ -142,12 +133,23 @@ public final class BuilderIOViewModel {
     isLoading = false
   }
 
+  func replaceLocalePlaceholder(in string: String, with locale: String) -> String {
+    let placeholder = "&locale={{state.locale}}"
+    if string.contains(placeholder) {
+      return string.replacingOccurrences(of: placeholder, with: "&locale=\(locale)")
+    } else {
+      return string
+    }
+  }
+
   /// Sends a tracking pixel to Builder.io.
   public func sendTrackingPixel() {
     BuilderIOManager.shared.sendTrackingPixel()
   }
 
-  public func fetchParallelAPIData(urls: [String: String]) async -> [String: AnyCodable] {
+  public func fetchParallelAPIData(urls: [String: String], locale: String) async -> [String:
+    AnyCodable]
+  {
     isLoading = true
     errorMessage = nil  // Clear any previous error
 
@@ -162,13 +164,18 @@ public final class BuilderIOViewModel {
 
     // Use withTaskGroup for concurrent execution and collection of results
     // The Task will now return (originalKey, apiResult)
-    await withTaskGroup(of: (String, AnyCodable?).self) { group in
+    await withTaskGroup(of: (String, AnyCodable?).self) { [weak self] group in
       for (key, urlString) in urls {  // Iterate over key-value pairs
         group.addTask {
           do {
-            let apiResult = try await BuilderContentAPI.getDataFromBoundAPI(url: urlString)
-            // Return the original key along with the API result
-            return (key, apiResult)
+            if let self = self {
+              let apiResult = try await BuilderContentAPI.getDataFromBoundAPI(
+                url: self.replaceLocalePlaceholder(in: urlString, with: locale))
+              // Return the original key along with the API result
+              return (key, apiResult)
+            } else {
+              return (key, nil)
+            }
           } catch {
             print(
               "Error fetching data from \(urlString) for key \(key): \(error.localizedDescription)")

--- a/Sources/BuilderIO/ExportedView/BuilderIOViewModel.swift
+++ b/Sources/BuilderIO/ExportedView/BuilderIOViewModel.swift
@@ -12,14 +12,24 @@ public final class BuilderIOViewModel {
   public var isLoading: Bool = false
   public var errorMessage: String?
   public var stateModel: StateModel = StateModel()
+  public var locale: String = "Default"
 
   public var isNetworkAvailable: Bool = false
   private let networkMonitor = NWPathMonitor()
   private let networkQueue = DispatchQueue(label: "NetworkMonitorQueue")
 
   /// Initializes the BuilderIOViewModel.
-  public init() {
+  public init(locale: String) {
+    self.locale = locale
     startNetworkMonitoring()
+  }
+
+  public func updateLocale(locale: String) {
+    self.locale = locale
+    for i in 0..<(self.builderContent?.data.blocks.count ?? 0) {
+      self.builderContent?.data.blocks[i].setLocaleRecursively(locale)
+    }
+
   }
 
   private func startNetworkMonitoring() {
@@ -67,7 +77,14 @@ public final class BuilderIOViewModel {
         }
 
         if self.stateModel.apiResponses.isEmpty {
+          var newContentBlocks = fetchedContent.data.blocks ?? []
+          for i in 0..<newContentBlocks.count {
+            newContentBlocks[i].setLocaleRecursively(locale)
+          }
+
           self.builderContent = fetchedContent
+
+          self.builderContent?.data.blocks = newContentBlocks
         } else {
           // Further logic for content binding/loops can go here if needed.
           var contentBlocks = fetchedContent.data.blocks ?? []
@@ -103,7 +120,12 @@ public final class BuilderIOViewModel {
             }
 
           }
+
           self.builderContent = fetchedContent
+
+          for i in 0..<newContentBlocks.count {
+            newContentBlocks[i].setLocaleRecursively(locale)
+          }
 
           self.builderContent?.data.blocks = newContentBlocks
         }

--- a/Sources/BuilderIO/Schemas/BuilderBlockModel.swift
+++ b/Sources/BuilderIO/Schemas/BuilderBlockModel.swift
@@ -17,6 +17,8 @@ public struct BuilderBlockModel: Codable, Identifiable {
   public var stateBoundObjectModel: StateModel? = nil
   public var stateRepeatCollectionKey: StateRepeatCollectionKey? = nil
 
+  public var locale: String? = nil  // Optional locale for the block
+
 }
 
 public struct StateRepeatCollectionKey: Codable {
@@ -85,6 +87,18 @@ extension BuilderBlockModel {
     }
 
     return nil
+  }
+
+  public mutating func setLocaleRecursively(_ newLocale: String) {
+    self.locale = newLocale
+    self.id = UUID().uuidString  // Reset ID to ensure uniqueness after locale change
+    if let children = self.children {
+      var newChildren = children
+      for i in 0..<newChildren.count {
+        newChildren[i].setLocaleRecursively(newLocale)
+      }
+      self.children = newChildren
+    }
   }
 
 }

--- a/Tests/BuilderIOTests/Helper/BuilderIOMockManager.swift
+++ b/Tests/BuilderIOTests/Helper/BuilderIOMockManager.swift
@@ -78,7 +78,7 @@ class BuilderIOMockManager {
       return  // loadJSONData will already have failed the test if file is missing
     }
 
-    guard let url = URL(string: "\(baseURLString)&url=\(endpoint)") else {
+    guard let url = URL(string: "\(baseURLString)&url=\(endpoint)&locale=Default") else {
       XCTFail("Invalid URL constructed for endpoint: \(endpoint)")
       return
     }


### PR DESCRIPTION
Added localization support to swift sdk targeting Text Images and Data Binding. 
Users will have to specify localization for the pages/sections or leaving blank set it as "Default". 
Every change to locale will trigger the content API call with the new values of locale thus refreshing the page.

*Added a fix to enable rendering of HTML lists OL LI in the text field. An issue with iOS 18 update needed it to be defined. 


Example for images and text. Change is between french and english 
 
https://github.com/user-attachments/assets/7166ecb4-1fe2-4890-86c4-f63423f8f57b


Example of data binding Again french video list has different video links.

https://github.com/user-attachments/assets/415fe53c-d3ba-46f1-91e6-b48674eee3df


HTML List view Rendering in Text

<img width="1179" height="2556" alt="Simulator Screenshot - iPhone 16 - 2025-08-06 at 16 45 55" src="https://github.com/user-attachments/assets/58bfc14a-3904-4f7d-98df-ae30022163c3" />

